### PR TITLE
Add linting configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 8,
+    "sourceType": "module"
+  },
+  "rules": {
+    "arrow-parens": ["error", "as-needed"],
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "max-len": ["warn"],
+    "no-console": ["error", { "allow": ["warn", "error"] }],
+    "prefer-arrow-callback": ["error"],
+    "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
+    "semi": ["error", "always"]
+  }
+}


### PR DESCRIPTION
Want to be consistent in code and to detect errors early.

Use these configs with their corresponding plugins in the editor of your choice.

For example, for VS Code, install [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) to use `.editorconfig` and [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) to use `.eslintrc.json`.