### PR TITLE
Remove 2 MySQL env variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_HOST: ${MYSQL_HOST}
-      MYSQL_PORT: ${MYSQL_PORT}
+      MYSQL_HOST: mysql
+      MYSQL_PORT: 3306
     depends_on:
       - mysql
 


### PR DESCRIPTION
`$MYSQL_HOST` and `$MYSQL_PORT` should be hard-coded into `docker-compose.yml` for the `api` service