### PR TITLE
Add CRUD functionality for Course's API endpoints

### DIFF
--- a/api/courses.js
+++ b/api/courses.js
@@ -8,7 +8,8 @@ const { validateAgainstSchema } = require('../lib/validation');
 const {
   CourseSchema,
   getCoursePage,
-  addCourse
+  addCourse,
+  getCourseById
 } = require('../models/course');
 
 /*
@@ -59,10 +60,10 @@ router.get('/', async (req, res, next) => {
  * authenticated User with admin role can create a new Course.
  */
 router.post('/', async (req, res, next) => {
-  // validate request body
   if (validateAgainstSchema(req.body, CourseSchema)) {
     try {
       const insertId = await addCourse(req.body);
+
       res.status(201).send({ id: insertId });
     } catch (err) {
       next(err);
@@ -71,6 +72,25 @@ router.post('/', async (req, res, next) => {
     res.status(400).send({
       error: 'The request body was not a valid Course object.'
     });
+  }
+});
+
+/*
+ * GET /courses/{id}
+ *
+ * Fetches data about a specific Course, excluding the list of Students enrolled
+ * in the course and the list of Assignments for the courses.
+ */
+router.get('/:id', async (req, res, next) => {
+  try {
+    const course = await getCourseById(parseInt(req.params.id));
+    if (course) {
+      res.status(200).send(course);
+    } else {
+      next();
+    }
+  } catch (err) {
+    next(err);
   }
 });
 

--- a/api/courses.js
+++ b/api/courses.js
@@ -39,14 +39,16 @@ router.get('/', async (req, res, next) => {
     const termQuery = term ? `&term=${term}` : '';
     // if not last page, provide links to next and last pages
     if (coursePage.currentPage < coursePage.totalPages) {
-      coursePage.links.nextPage = `/courses?page=${coursePage.currentPage + 1}` +
+      coursePage.links.nextPage =
+        `/courses?page=${coursePage.currentPage + 1}` +
           subjectQuery + numberQuery + termQuery;
       coursePage.links.lastPage = `/courses?page=${coursePage.totalPages}` +
           subjectQuery + numberQuery + termQuery;
     }
     // if not first page, provide links to previous and first pages
     if (coursePage.currentPage > 1) {
-      coursePage.links.prevPage = `/courses?page=${coursePage.currentPage - 1}` +
+      coursePage.links.prevPage =
+        `/courses?page=${coursePage.currentPage - 1}` +
           subjectQuery + numberQuery + termQuery;
       coursePage.links.firstPage = `/courses?page=1` +
           subjectQuery + numberQuery + termQuery;
@@ -88,7 +90,8 @@ router.post('/', async (req, res, next) => {
  */
 router.get('/:id', async (req, res, next) => {
   try {
-    const course = await getCourseById(parseInt(req.params.id));
+    const id = parseInt(req.params.id);
+    const course = await getCourseById(id);
     if (course) {
       res.status(200).send(course);
     } else {

--- a/api/courses.js
+++ b/api/courses.js
@@ -4,14 +4,15 @@
 
 const router = require('express').Router();
 
+const { validateAgainstSchema } = require('../lib/validation');
 const {
   CourseSchema,
   getCoursePage,
+  addCourse
 } = require('../models/course');
 
 /*
  * GET /courses
- * GET /courses?page=3
  *
  * Fetches the paginated list of all Courses. The Courses returned do not
  * contain the list of Students in the Course or the Assignments for the Course.
@@ -48,6 +49,28 @@ router.get('/', async (req, res, next) => {
     res.status(200).send(coursePage);
   } catch (err) {
     next(err);
+  }
+});
+
+/*
+ * POST /courses
+ *
+ * Creates a new Course with specified data and adds it to the database. Only
+ * authenticated User with admin role can create a new Course.
+ */
+router.post('/', async (req, res, next) => {
+  // validate request body
+  if (validateAgainstSchema(req.body, CourseSchema)) {
+    try {
+      const insertId = await addCourse(req.body);
+      res.status(201).send({ id: insertId });
+    } catch (err) {
+      next(err);
+    }
+  } else {
+    res.status(400).send({
+      error: 'The request body was not a valid Course object.'
+    });
   }
 });
 

--- a/api/courses.js
+++ b/api/courses.js
@@ -13,7 +13,8 @@ const {
   getCoursePage,
   addCourse,
   getCourseById,
-  updateCourseById
+  updateCourseById,
+  deleteCourseById
 } = require('../models/course');
 
 /*
@@ -101,8 +102,8 @@ router.get('/:id', async (req, res, next) => {
 /*
  * PATCH /courses/{id}
  *
- * Performs a partial update on the data for the Course. The enrolled Students
- * and Assignments for the Course will not be modified via this endpoint.
+ * Performs a partial update on the data for the Course. Enrolled Students and
+ * Assignments for the Course will not be modified via this endpoint.
  *
  * Only an authenticated admin User or an authenticated instructor User whose
  * ID matches the `instructor_id` of the Course can update Course information.
@@ -124,6 +125,23 @@ router.patch('/:id', async (req, res, next) => {
     res.status(400).send({
       error: 'The request body did not contain any valid Course field.'
     });
+  }
+});
+
+/*
+ * DELETE /courses/{id}
+ *
+ * Completely removes the data for the specified Course, including all enrolled
+ * Students, all Assignments, etc.
+ *
+ * Only an authenticated admin User can remove a Course.
+ */
+router.delete('/:id', async (req, res, next) => {
+  const deleteSuccess = await deleteCourseById(parseInt(req.params.id));
+  if (deleteSuccess) {
+    res.status(204).send();
+  } else {
+    next();
   }
 });
 

--- a/api/courses.js
+++ b/api/courses.js
@@ -5,32 +5,44 @@
 const router = require('express').Router();
 
 const {
-  getCoursePage
+  CourseSchema,
+  getCoursePage,
 } = require('../models/course');
 
 /*
  * GET /courses
  * GET /courses?page=3
  *
- * Fetches a paginated list of all Courses.
- * The URL parameter  page  is optional; if not specified, displays page 1.
+ * Fetches the paginated list of all Courses. The Courses returned do not
+ * contain the list of Students in the Course or the Assignments for the Course.
  */
 router.get('/', async (req, res, next) => {
   try {
+    // collect URL parameters
     const currentPage = parseInt(req.query.page) || 1;
+    const subject = req.query.subject || '';
+    const number = req.query.number || '';
+    const term = req.query.term || '';
 
     // fetch current page's info and generate HATEOAS links of surrounding pages
-    const coursePage = await getCoursePage(currentPage);
+    const coursePage = await getCoursePage(currentPage, subject, number, term);
     coursePage.links = {};
+    const subjectQuery = subject ? `&subject=${subject}` : '';
+    const numberQuery = number ? `&number=${number}` : '';
+    const termQuery = term ? `&term=${term}` : '';
     // if not last page, provide links to next and last pages
     if (coursePage.currentPage < coursePage.totalPages) {
-      coursePage.links.nextPage = `/courses?page=${coursePage.currentPage + 1}`;
-      coursePage.links.lastPage = `/courses?page=${coursePage.totalPages}`;
+      coursePage.links.nextPage = `/courses?page=${coursePage.currentPage + 1}` +
+          subjectQuery + numberQuery + termQuery;
+      coursePage.links.lastPage = `/courses?page=${coursePage.totalPages}` +
+          subjectQuery + numberQuery + termQuery;
     }
     // if not first page, provide links to previous and first pages
     if (coursePage.currentPage > 1) {
-      coursePage.links.prevPage = `/courses?page=${coursePage.currentPage - 1}`;
-      coursePage.links.firstPage = `/courses?page=1`;
+      coursePage.links.prevPage = `/courses?page=${coursePage.currentPage - 1}` +
+          subjectQuery + numberQuery + termQuery;
+      coursePage.links.firstPage = `/courses?page=1` +
+          subjectQuery + numberQuery + termQuery;
     }
 
     res.status(200).send(coursePage);

--- a/api/courses.js
+++ b/api/courses.js
@@ -1,0 +1,42 @@
+/*
+ * API route middleware functions for the Course entity.
+ */
+
+const router = require('express').Router();
+
+const {
+  getCoursePage
+} = require('../models/course');
+
+/*
+ * GET /courses
+ * GET /courses?page=3
+ *
+ * Fetches a paginated list of all Courses.
+ * The URL parameter  page  is optional; if not specified, displays page 1.
+ */
+router.get('/', async (req, res, next) => {
+  try {
+    const currentPage = parseInt(req.query.page) || 1;
+
+    // fetch current page's info and generate HATEOAS links of surrounding pages
+    const coursePage = await getCoursePage(currentPage);
+    coursePage.links = {};
+    // if not last page, provide links to next and last pages
+    if (coursePage.currentPage < coursePage.totalPages) {
+      coursePage.links.nextPage = `/courses?page=${coursePage.currentPage + 1}`;
+      coursePage.links.lastPage = `/courses?page=${coursePage.totalPages}`;
+    }
+    // if not first page, provide links to previous and first pages
+    if (coursePage.currentPage > 1) {
+      coursePage.links.prevPage = `/courses?page=${coursePage.currentPage - 1}`;
+      coursePage.links.firstPage = `/courses?page=1`;
+    }
+
+    res.status(200).send(coursePage);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/api/index.js
+++ b/api/index.js
@@ -1,3 +1,5 @@
 const router = require('express').Router();
 
+router.use('/courses', require('./courses'));
+
 module.exports = router;

--- a/db-init/00-db-init.sql
+++ b/db-init/00-db-init.sql
@@ -108,14 +108,14 @@ INSERT INTO `assignments`
   (`id`, `course_id`, `title`, `points`, `due`)
 VALUES
   (1, 1, 'Assignment 1: API Design, Implementation, and Containerization', 100, '2019-04-23T23:59:59-07:00'),
-  (2, 1, 'Assignment 2: API Data Storage', 90, '2019-05-06T23:59:59-07:00'),
+  (2, 1, 'Assignment 2: API Data Storage', 100, '2019-05-06T23:59:59-07:00'),
   (3, 1, 'Assignment 3: API Authentication and Authorization', 100, '2019-05-20T23:59:59-07:00'),
   (4, 1, 'Assignment 4: File Uploads and Offline Work', 100, '2019-06-03T23:59:59-07:00'),
   (5, 2, 'Homework 3: Dynamic Programming', 100, '2019-03-13T23:59:59-07:00'),
-  (6, 3, 'Program 3: Smallsh', 135, '2019-03-05T23:59:59-08:00'),
+  (6, 3, 'Program 3: Smallsh', 100, '2019-03-05T23:59:59-08:00'),
   (7, 15, 'Homework 6', 100, '2018-04-23T23:59:59-07:00'),
-  (8, 8, 'Assignment 2: Parsing and Syntax-Directed Translation', 86, '2019-05-13T23:59:59-07:00'),
-  (9, 8, 'Assignment 3: Abstract Syntax Trees and Simple Code Generation', 94, '2019-05-27T23:59:59-07:00'),
+  (8, 8, 'Assignment 2: Parsing and Syntax-Directed Translation', 100, '2019-05-13T23:59:59-07:00'),
+  (9, 8, 'Assignment 3: Abstract Syntax Trees and Simple Code Generation', 100, '2019-05-27T23:59:59-07:00'),
   (10, 18, 'Project Step 7: Turn in Final Working Project', 100, '2019-03-19T23:59:59-07:00');
 
 --

--- a/db-init/00-db-init.sql
+++ b/db-init/00-db-init.sql
@@ -133,4 +133,31 @@ CREATE TABLE `submissions` (
   FOREIGN KEY (`student_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+--
+-- Table structure for table `courses_students`
+-- (Since Course and Student have a many-to-many relationship)
+--
+DROP TABLE IF EXISTS `courses_students`;
+CREATE TABLE `courses_students` (
+  `course_id` INT(10) UNSIGNED NOT NULL,
+  `student_id` INT(10) UNSIGNED NOT NULL,
+  UNIQUE (`course_id`, `student_id`),
+  FOREIGN KEY (`course_id`) REFERENCES `courses`(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`student_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `courses_students`
+--
+INSERT INTO `courses_students`
+  (`course_id`, `student_id`)
+VALUES
+  (1, 2), (1, 5), (1, 6),
+  (3, 1), (3, 7),
+  (4, 5), (4, 8), (4, 9),
+  (7, 2), (7, 5), (7, 6), (7, 7), (7, 8),
+  (9, 2), (9, 6), (9, 7),(9, 8),
+  (17, 5), (17, 6),
+  (19, 12);
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -21,7 +21,7 @@ exports.requireAuthentication = function (req, res, next) {
 
   try {
     const payload = jwt.verify(token, secretKey);
-    req.user = payload.sub;
+    req.authenticatedUserId = payload.sub;
     next();
   } catch (err) {
     console.error("  -- error:", err);

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,63 +1,88 @@
 /*
- * If an object has a truthy field, then it is considered to have that field.
- * If an object has a falsy field that is in the following set:
- * - false
- * - 0
- * then it is considered to have that field.
+ * Performs data validation on an object by verifying that it contains
+ * all **required** fields specified in a given schema.
  *
- * Returns true if  obj  is considered to have  field .
- * Returns false otherwise.
+ * Returns true if the object is valid against the schema and false otherwise.
  *
- * Assume that  obj  is a valid JavaScript object.
+ * Notes:
+ * - If a field is _not_ required by the schema, then it doesn't matter if the
+ * object has that field or not---it will be a valid case.
+ * - If a field is required by the schema, then the object must "have" it for
+ * this case to be valid.
+ * - The definition of an object "having" a field is defined by the
+ * `objHasField()` helper function below.
+ * - This function won't care if the provided object has extra fields that are
+ * not in the schema, as filtering out those field is the job of the
+ * `extractValidFields()` function.
+ *
+ * It is strongly recommended to use this function to validate a request body
+ * **before** extracting valid fields out of it.
  */
-function objHasField(obj, field) {
-  return obj[field] || obj[field] === false || obj[field] === 0;
+function validateAgainstSchema(obj, schema) {
+  return obj && Object.keys(schema).every(field =>
+    !schema[field].required || objectHasField(obj, field)
+  );
 }
+exports.validateAgainstSchema = validateAgainstSchema;
 
 /*
  * Performs data validation on an object by verifying that it contains
- * all required fields specified in a given schema.
- *
- * Returns true if the object is valid agianst the schema and false otherwise.
- */
-exports.validateAgainstSchema = function (obj, schema) {
-  return obj && Object.keys(schema).every(
-    field => !schema[field].required || objHasField(obj, field)
-  );
-};
-
-/*
- * Performs data validation on an object by verifying that it contains at least
- * one field specified in a given schema. It does not matter if that field is
- * required or not. As long as this "patch" object has a field which the schema
- * also has, then this object is valid.
+ * **at least one** field specified in a given schema.
  *
  * Returns true if the object is valid against the schema and false otherwise.
+ *
+ * Notes:
+ * - It does not matter if the field is required by the schema or not. If the
+ * object and the schema both "have" that field, then it is a valid case.
+ * - The definition of an object "having" a field is defined by the
+ * `objHasField()` helper function below.
+ * - This function won't care if the provided object has extra fields that are
+ * not in the schema, as filtering out those field is the job of the
+ * `extractValidFields()` function.
+ *
+ * It is strongly recommended to use this function to validate a PATCH request
+ * body **before** extracting valid fields out of it.
  */
-exports.validatePatchAgainstSchema = (patchObj, schema) => {
-  return patchObj &&
-      Object.keys(patchObj).some(field =>
-        objHasField(patchObj, field) && schema[field]
-      );
-};
+function validatePatchAgainstSchema(patchObj, schema) {
+  return (
+    patchObj &&
+    Object.keys(patchObj).some(field =>
+      schema[field] && objectHasField(patchObj, field)
+    )
+  );
+}
+exports.validatePatchAgainstSchema = validatePatchAgainstSchema;
 
 /*
  * Extracts all fields from an object that are valid according to a specified
- * schema.  Extracted fields can be either required or optional.
+ * schema. Extracted fields can be either required or optional.
+ * Simply put, this function will intersect the provided object with the schema.
  *
- * Returns a new object containing all valid fields extracted from the
- * original object.
+ * Returns a new object containing all valid fields extracted from the original
+ * object.
  */
-exports.extractValidFields = function (obj, schema) {
+function extractValidFields(obj, schema) {
   let validObj = {};
-
   if (obj) {
-    Object.keys(schema).forEach((field) => {
-      if (objHasField(obj, field)) {
+    Object.keys(schema).forEach(field => {
+      if (objectHasField(obj, field)) {
         validObj[field] = obj[field];
       }
     });
   }
-
   return validObj;
-};
+}
+exports.extractValidFields = extractValidFields;
+
+/*
+ * If an object has a truthy field, then it is considered to "have" that field.
+ * If an object has a falsy field that is in the following set:
+ * - false
+ * - 0
+ * then it is considered to "have" that field.
+ *
+ * Returns true if the object has the field and false otherwise.
+ */
+function objectHasField(obj, field) {
+  return obj[field] || obj[field] === false || obj[field] === 0;
+}

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -27,6 +27,21 @@ exports.validateAgainstSchema = function (obj, schema) {
 };
 
 /*
+ * Performs data validation on an object by verifying that it contains at least
+ * one field specified in a given schema. It does not matter if that field is
+ * required or not. As long as this "patch" object has a field which the schema
+ * also has, then this object is valid.
+ *
+ * Returns true if the object is valid against the schema and false otherwise.
+ */
+exports.validatePatchAgainstSchema = (patchObj, schema) => {
+  return patchObj &&
+      Object.keys(patchObj).some(field =>
+        objHasField(patchObj, field) && schema[field]
+      );
+};
+
+/*
  * Extracts all fields from an object that are valid according to a specified
  * schema.  Extracted fields can be either required or optional.
  *

--- a/models/course.js
+++ b/models/course.js
@@ -6,8 +6,8 @@ const mysqlPool = require('../lib/mysqlPool');
 const { extractValidFields } = require('../lib/validation');
 
 /*
- * This schema is used for validating the content of the request body before
- * inserting it to the database.
+ * This schema is used for validating the required content of the request body
+ * before inserting it to the database.
  */
 const CourseSchema = {
   subject: { required: true },
@@ -19,19 +19,21 @@ const CourseSchema = {
 exports.CourseSchema = CourseSchema;
 
 /*
- * Returns a Promise that
- * - resolves to an object containing info of a page of existing courses, or
- * - rejects with an error on failure.
+ * Fetches a paginated list of all Courses.
  *
  * Params:
  *   page     Page of Courses to fetch. Default to 1 if not specified.
  *   subject  Fetch only Courses with the specified subject code.
  *   number   Fetch only Courses with the specified course number.
  *   term     Fetch only Courses with the specified academic term.
+ *
+ * Returns a Promise that
+ * - resolves to an object that contains info of a page of existing courses, or
+ * - rejects with an error on failure.
  */
 function getCoursePage(page, subject, number, term) {
   return new Promise((resolve, reject) => {
-    // filter Course's subject, number, and term if provided
+    // filter Course's subject, number, and term if they are provided
     // otherwise, `LIKE %%` will be used to match all patterns
     const sql =
       `SELECT *
@@ -89,13 +91,14 @@ function getCoursePage(page, subject, number, term) {
 exports.getCoursePage = getCoursePage;
 
 /*
- * Inserts a Course into the database and returns a Promise that
+ * Inserts a Course into the database.
+ *
+ * Returns a Promise that
  * - resolves to the ID of the newly inserted object on success, or
  * - rejects with an error on failure.
  */
 function addCourse(course) {
   return new Promise((resolve, reject) => {
-    // use only the fields specified in the schema
     const newCourse = extractValidFields(course, CourseSchema);
 
     const sql = 'INSERT INTO courses SET ?';
@@ -111,10 +114,13 @@ function addCourse(course) {
 exports.addCourse = addCourse;
 
 /*
+ * Fetch data about a specific Course.
+ *
  * Returns a Promise that
  * - resolves to a Course object with the specified ID on success, or
  * - reject with an error on failure.
  *
+ * Notes:
  * Does not fetch Students enrolled in the Course or Assignments for the Course.
  */
 function getCourseById(id) {
@@ -132,10 +138,13 @@ function getCourseById(id) {
 exports.getCourseById = getCourseById;
 
 /*
- * Partially updates a Course and returns a Promise that
- * - resolves to a successful status on success, or
+ * Updates data for a specific Course.
+ *
+ * Returns a Promise that
+ * - resolves to true on successful update or false on non-update, or
  * - rejects with an error on failure.
  *
+ * Notes:
  * Does not modify this Course's Students and Assignments.
  */
 function updateCourseById(id, course) {
@@ -168,12 +177,15 @@ function updateCourseById(id, course) {
 exports.updateCourseById = updateCourseById;
 
 /*
- * Deletes a Course based on its ID. All Students enrolling in this Course and
- * all Assignments for this Course will also be deleted.
+ * Removes a specific Course from the database.
  *
  * Returns a Promise that
- * - resolves to a successful status on success, or
+ * - resolves to true on successful removal or false on non-removal, or
  * - rejects with an error on failure.
+ *
+ * Notes:
+ * All Students enrolling in this Course and all Assignments for this Course
+ * will also be removed.
  */
 function deleteCourseById(id) {
   return new Promise((resolve, reject) => {

--- a/models/course.js
+++ b/models/course.js
@@ -3,6 +3,7 @@
  */
 
 const mysqlPool = require('../lib/mysqlPool');
+const { extractValidFields } = require('../lib/validation');
 
 /*
  * This schema is used for validating the content of the request body before
@@ -86,3 +87,25 @@ function getCoursePage(page, subject, number, term) {
   });
 }
 exports.getCoursePage = getCoursePage;
+
+/*
+ * Inserts a Course into the database and returns a Promise that
+ * - resolves to the ID of the newly inserted object on success, or
+ * - rejects with an error on failure.
+ */
+function addCourse(course) {
+  return new Promise((resolve, reject) => {
+    // use only the fields specified in the schema
+    course = extractValidFields(course, CourseSchema);
+
+    const sql = 'INSERT INTO courses SET ?';
+    mysqlPool.query(sql, course, (err, results) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(results.insertId);
+      }
+    });
+  });
+}
+exports.addCourse = addCourse;

--- a/models/course.js
+++ b/models/course.js
@@ -135,6 +135,8 @@ exports.getCourseById = getCourseById;
  * Partially updates a Course and returns a Promise that
  * - resolves to a successful status on success, or
  * - rejects with an error on failure.
+ *
+ * Does not modify this Course's Students and Assignments.
  */
 function updateCourseById(id, course) {
   return new Promise((resolve, reject) => {
@@ -164,3 +166,25 @@ function updateCourseById(id, course) {
   });
 }
 exports.updateCourseById = updateCourseById;
+
+/*
+ * Deletes a Course based on its ID. All Students enrolling in this Course and
+ * all Assignments for this Course will also be deleted.
+ *
+ * Returns a Promise that
+ * - resolves to a successful status on success, or
+ * - rejects with an error on failure.
+ */
+function deleteCourseById(id) {
+  return new Promise((resolve, reject) => {
+    const sql = 'DELETE FROM courses WHERE id = ?';
+    mysqlPool.query(sql, [id], (err, results) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(results.affectedRows > 0);
+      }
+    });
+  });
+}
+exports.deleteCourseById = deleteCourseById;

--- a/models/course.js
+++ b/models/course.js
@@ -96,10 +96,10 @@ exports.getCoursePage = getCoursePage;
 function addCourse(course) {
   return new Promise((resolve, reject) => {
     // use only the fields specified in the schema
-    const extractedCourse = extractValidFields(course, CourseSchema);
+    const newCourse = extractValidFields(course, CourseSchema);
 
     const sql = 'INSERT INTO courses SET ?';
-    mysqlPool.query(sql, extractedCourse, (err, results) => {
+    mysqlPool.query(sql, newCourse, (err, results) => {
       if (err) {
         reject(err);
       } else {
@@ -130,3 +130,37 @@ function getCourseById(id) {
   });
 }
 exports.getCourseById = getCourseById;
+
+/*
+ * Partially updates a Course and returns a Promise that
+ * - resolves to a successful status on success, or
+ * - rejects with an error on failure.
+ */
+function updateCourseById(id, course) {
+  return new Promise((resolve, reject) => {
+    const newCourse = extractValidFields(course, CourseSchema);
+    const newCourseKeys = Object.keys(newCourse);
+
+    let newCourseQuery = '';
+    newCourseKeys.forEach((field, index) => {
+      newCourseQuery += `${field} = ?`;
+      if (index < newCourseKeys.length - 1) {
+        newCourseQuery += ', ';
+      }
+    });
+
+    // values to be escaped and put into the database query
+    const queryValues = Object.values(newCourse);
+    queryValues.push(id);
+
+    const sql = `UPDATE courses SET ${newCourseQuery} WHERE id = ?`;
+    mysqlPool.query(sql, queryValues, (err, results) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(results.affectedRows > 0);
+      }
+    });
+  });
+}
+exports.updateCourseById = updateCourseById;

--- a/models/course.js
+++ b/models/course.js
@@ -1,0 +1,79 @@
+/*
+ * Data-access functions for the Course entity.
+ */
+
+const mysqlPool = require('../lib/mysqlPool');
+
+/*
+ * This schema is used for validating the content of the request body before
+ * inserting it to the database.
+ */
+const courseSchema = {
+  subject: { required: true },
+  number: { required: true },
+  title: { required: true },
+  term: { required: true },
+  instructor_id: { required: true }
+};
+exports.courseSchema = courseSchema;
+
+/*
+ * Returns a Promise that
+ * - resolves to the number of existing courses on success, or
+ * - rejects with an error on failure.
+ */
+function countCourses() {
+  return new Promise((resolve, reject) => {
+    const mysqlQuery = 'SELECT COUNT(id) AS count FROM courses';
+    mysqlPool.query(mysqlQuery, (err, results) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(results[0].count);
+      }
+    });
+  });
+}
+
+/*
+ * Returns a Promise that
+ * - resolves to an object containing info of a page of existing courses, or
+ * - rejects with an error on failure.
+ */
+function getCoursePage(currentPage) {
+  return new Promise(async (resolve, reject) => {
+    const numCourses = await countCourses();
+    const pageSize = 10;  // courses per page
+
+    // e.g. if 29 courses in total,
+    //   then page 1 (1-10), page 2 (11-20), page 3 (21-29)
+    // e.g. if 30 courses in total,
+    //   then page 1 (1-10), page 2 (11-20), page 3 (21-30)
+    // e.g. if 31 courses in total,
+    //   then page 1 (1-10), page 2 (11-20), page 3 (21-30), page 4 (31)
+    const lastPage = Math.ceil(numCourses / pageSize);
+
+    // make sure the current page is within [1..lastPage]
+    currentPage = (currentPage > lastPage) ? lastPage : currentPage;
+    currentPage = (currentPage < 1) ? 1 : currentPage;
+
+    // e.g. if on page 2, the offset will be 10 courses
+    const offset = (currentPage - 1) * pageSize;
+
+    const mysqlQuery = 'SELECT * FROM courses ORDER BY id LIMIT ?, ?';
+    mysqlPool.query(mysqlQuery, [offset, pageSize], (err, results) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({
+          courses: results,
+          currentPage: currentPage,
+          totalPages: lastPage,
+          pageSize: pageSize,
+          totalCourses: numCourses
+        });
+      }
+    });
+  });
+}
+exports.getCoursePage = getCoursePage;

--- a/models/course.js
+++ b/models/course.js
@@ -8,72 +8,81 @@ const mysqlPool = require('../lib/mysqlPool');
  * This schema is used for validating the content of the request body before
  * inserting it to the database.
  */
-const courseSchema = {
+const CourseSchema = {
   subject: { required: true },
   number: { required: true },
   title: { required: true },
   term: { required: true },
   instructor_id: { required: true }
 };
-exports.courseSchema = courseSchema;
-
-/*
- * Returns a Promise that
- * - resolves to the number of existing courses on success, or
- * - rejects with an error on failure.
- */
-function countCourses() {
-  return new Promise((resolve, reject) => {
-    const mysqlQuery = 'SELECT COUNT(id) AS count FROM courses';
-    mysqlPool.query(mysqlQuery, (err, results) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(results[0].count);
-      }
-    });
-  });
-}
+exports.CourseSchema = CourseSchema;
 
 /*
  * Returns a Promise that
  * - resolves to an object containing info of a page of existing courses, or
  * - rejects with an error on failure.
+ *
+ * Params:
+ *   page     Page of Courses to fetch. Default to 1 if not specified.
+ *   subject  Fetch only Courses with the specified subject code.
+ *   number   Fetch only Courses with the specified course number.
+ *   term     Fetch only Courses with the specified academic term.
  */
-function getCoursePage(currentPage) {
-  return new Promise(async (resolve, reject) => {
-    const numCourses = await countCourses();
-    const pageSize = 10;  // courses per page
+function getCoursePage(page, subject, number, term) {
+  return new Promise((resolve, reject) => {
+    // filter Course's subject, number, and term if provided
+    // otherwise, `LIKE %%` will be used to match all patterns
+    const sql =
+      `SELECT *
+      FROM (
+        SELECT *
+        FROM courses
+        WHERE
+          LOWER(subject) ${subject ? '= ?' : 'LIKE ?'}
+          AND LOWER(number) ${number ? '= ?' : 'LIKE ?'}
+          AND LOWER(term) ${term ? '= ?' : 'LIKE ?'}
+      ) AS t
+      ORDER BY id ASC`;
+    mysqlPool.query(
+      sql,
+      [
+        subject ? subject : '%%',
+        number ? number : '%%',
+        term ? term : '%%',
+      ],
+      (err, results) => {
+        if (err) {
+          reject(err);
+        } else {
+          // pagination must come after filtering
+          const numCourses = results.length;
+          const pageSize = 10;  // Courses per page
 
-    // e.g. if 29 courses in total,
-    //   then page 1 (1-10), page 2 (11-20), page 3 (21-29)
-    // e.g. if 30 courses in total,
-    //   then page 1 (1-10), page 2 (11-20), page 3 (21-30)
-    // e.g. if 31 courses in total,
-    //   then page 1 (1-10), page 2 (11-20), page 3 (21-30), page 4 (31)
-    const lastPage = Math.ceil(numCourses / pageSize);
+          // e.g. if 31 Courses in total, then
+          // page 1 (1-10), page 2 (11-20), page 3 (21-30), page 4 (31)
+          const lastPage = Math.ceil(numCourses / pageSize);
 
-    // make sure the current page is within [1..lastPage]
-    currentPage = (currentPage > lastPage) ? lastPage : currentPage;
-    currentPage = (currentPage < 1) ? 1 : currentPage;
+          // force the current page to be within [1..lastPage]
+          page = (page > lastPage) ? lastPage : page;
+          page = (page < 1) ? 1 : page;
 
-    // e.g. if on page 2, the offset will be 10 courses
-    const offset = (currentPage - 1) * pageSize;
+          // e.g. if on page 2, the offset will be 10 courses
+          const offset = (page - 1) * pageSize;
 
-    const mysqlQuery = 'SELECT * FROM courses ORDER BY id LIMIT ?, ?';
-    mysqlPool.query(mysqlQuery, [offset, pageSize], (err, results) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve({
-          courses: results,
-          currentPage: currentPage,
-          totalPages: lastPage,
-          pageSize: pageSize,
-          totalCourses: numCourses
-        });
+          // array indices start at 0,
+          // so the page starts at offset and stops before offset + pageSize
+          results = results.slice(offset, offset + pageSize);
+
+          resolve({
+            courses: results,
+            currentPage: page,
+            totalPages: lastPage,
+            pageSize: pageSize,
+            totalCourses: numCourses
+          });
+        }
       }
-    });
+    );
   });
 }
 exports.getCoursePage = getCoursePage;

--- a/models/course.js
+++ b/models/course.js
@@ -96,10 +96,10 @@ exports.getCoursePage = getCoursePage;
 function addCourse(course) {
   return new Promise((resolve, reject) => {
     // use only the fields specified in the schema
-    course = extractValidFields(course, CourseSchema);
+    const extractedCourse = extractValidFields(course, CourseSchema);
 
     const sql = 'INSERT INTO courses SET ?';
-    mysqlPool.query(sql, course, (err, results) => {
+    mysqlPool.query(sql, extractedCourse, (err, results) => {
       if (err) {
         reject(err);
       } else {
@@ -109,3 +109,24 @@ function addCourse(course) {
   });
 }
 exports.addCourse = addCourse;
+
+/*
+ * Returns a Promise that
+ * - resolves to a Course object with the specified ID on success, or
+ * - reject with an error on failure.
+ *
+ * Does not fetch Students enrolled in the Course or Assignments for the Course.
+ */
+function getCourseById(id) {
+  return new Promise((resolve, reject) => {
+    const sql = 'SELECT * FROM courses WHERE id = ?';
+    mysqlPool.query(sql, [id], (err, results) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(results[0]);
+      }
+    });
+  });
+}
+exports.getCourseById = getCourseById;

--- a/server.js
+++ b/server.js
@@ -17,18 +17,35 @@ app.use(bodyParser.json());
 app.use(express.static('public'));
 
 /*
- * All routes for the API are written in modules in the api/ directory.  The
- * top-level router lives in api/index.js.  That's what we include here, and
+ * All routes for the API are written in modules in the api/ directory. The
+ * top-level router lives in api/index.js. That's what we include here, and
  * it provides all of the routes.
  */
 app.use('/', api);
 
-app.use('*', function (req, res, next) {
+/*
+ * To respond with 404 error in any route handler middleware function, call
+ *     next();
+ */
+app.use('*', (req, res) => {
   res.status(404).json({
-    error: "Requested resource " + req.originalUrl + " does not exist"
+    error: `Requested resource ${req.originalUrl} does not exist.`
   });
 });
 
-app.listen(port, function() {
-  console.log("== Server is running on port", port);
+/*
+ * To respond with 500 error in any route handler middleware function, call
+ *     next(err);
+ */
+// eslint-disable-next-line no-unused-vars
+app.use('*', (err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({
+    error: 'An error occurred. Try again later.'
+  });
+});
+
+app.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`== Server is running on port ${port}.`);
 });


### PR DESCRIPTION
TODOs:

- [ ] Authentication for routes that require it.
- [ ] The remaining requests which involve foreign keys: GET/POST Course's Students, GET Course's Assignments and Roster).
- [x] Add an extra table to deal with the many-to-many relationship between `Course` and `Student`.

Although this is a work in progress, the APIs for CRUD functionality of the `Course` entity is a major development and is pull-request worthy